### PR TITLE
fix: Remove extra closing brace in step 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,12 @@ studio.app.localhost {
     reverse_proxy kong:8000
 }
 
-  auth.app.localhost {
+auth.app.localhost {
     reverse_proxy authelia:9091
-  }
+}
 
-  supabase.app.localhost {
+supabase.app.localhost {
     reverse_proxy kong:8000
-  }
-
 }
 ```
 # Step 6


### PR DESCRIPTION
- Corrected a syntax error caused by an extra closing brace (`}`) in the Caddyfile, which resulted in a configuration error and prevented Caddy from starting properly. This change ensures the Caddyfile adheres to valid syntax.